### PR TITLE
get_objects return is consistent

### DIFF
--- a/datastore_entity/datastore_entity.py
+++ b/datastore_entity/datastore_entity.py
@@ -467,28 +467,23 @@ class DatastoreEntity():
         query_res = query.fetch(start_cursor=cursor, limit=limit)
 
         if paginate:
-            query_res = query.fetch(start_cursor=cursor, limit=limit)
             current_page = next(query_res.pages)
             entities = list(current_page)
             next_cursor = query_res.next_page_token.decode('utf-8')
         else:
-            entities = list(query.fetch(start_cursor=cursor, limit=limit))
+            entities = list(query_res)
 
-        if entities:
-            objs = []
-            for entity in entities:
+        objs = []
+        for entity in entities:
+            # get all properties. note that properties may not be
+            # defined in the class
+            for k, v in entity.items():
+                setattr(self, k, v)
 
-                # get all properties. note that properties may not be
-                # defined in the class
-                for k, v in entity.items():
-                    setattr(self, k, v)
+            self.key = entity.key
 
-                self.key = entity.key
-
-                objs.append(self)
-            return (objs, next_cursor)
-        else:
-            return None
+            objs.append(self)
+        return (objs, next_cursor)
 
     def __str__(self):
         return f'<Entity Kind: {self.__kind__}>'


### PR DESCRIPTION
Refactors get_objects a bit to reduce requests made to datastore.

Also ensures that a tuple is always returned, rather than tuple if items found, or None if not found.